### PR TITLE
Include definition of Name class in last example

### DIFF
--- a/_posts/2012-02-01-mappings-via-classmapbuilder.textile
+++ b/_posts/2012-02-01-mappings-via-classmapbuilder.textile
@@ -166,6 +166,13 @@ h4. Mapping nested multi-occurrence elements
 Nested multi-occurrence elements (of Array, Collection or Map) can also be mapped, by using syntax similar to that used for referencing individual indices of Arrays, Lists or Maps. Suppose we have the class structure given below:
 
 <pre class="prettyprint">
+class Name {
+   private String first;
+   private String last;
+   private String fullName;
+   // getters/setters 
+}
+
 class Person {
    private List<Name> names;
    // getters/setters 
@@ -192,4 +199,3 @@ A few things to note:
 * The element of a Map is assumed to be of type Map.Entry, so we can refer to either the 'key' or 'value' property of this element.
 * Nested properties are legal within the braces, and so are nested _element_ references, in case the element type itself also contains multi-occurrence fields that you want to map.  
 * The empty field name within the braces ("names{}") is used to refer to the element itself (rather than some property of the element).
-


### PR DESCRIPTION
I had a hard time understanding this example. Part of it was due to the typo in pull request 3, but another part was because I didn't realize immediately that Person had a list of Name objects instead of Strings.

Every other example stands alone from the others, so I was surprised this one didn't.

However, this isn't a clear improvement, so I'll understand if you reject this.
